### PR TITLE
Fix schema version serialization

### DIFF
--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -37,7 +37,7 @@ import { safeExecute } from './utils/safeExecute';
  * run state is compatible with the current version of the SDK.
  * If anything in this schema changes, the version will have to be incremented.
  */
-const CURRENT_SCHEMA_VERSION = '1.0' as const;
+export const CURRENT_SCHEMA_VERSION = '1.0' as const;
 const $schemaVersion = z.literal(CURRENT_SCHEMA_VERSION);
 
 const serializedAgentSchema = z.object({
@@ -349,7 +349,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    */
   toJSON(): z.infer<typeof SerializedRunState> {
     const output = {
-      $schemaVersion: '1.0',
+      $schemaVersion: CURRENT_SCHEMA_VERSION,
       currentTurn: this._currentTurn,
       currentAgent: {
         name: this._currentAgent.name,

--- a/packages/agents-core/test/runState.test.ts
+++ b/packages/agents-core/test/runState.test.ts
@@ -4,6 +4,7 @@ import {
   buildAgentMap,
   deserializeModelResponse,
   deserializeItem,
+  CURRENT_SCHEMA_VERSION,
 } from '../src/runState';
 import { RunContext } from '../src/runContext';
 import { Agent } from '../src/agent';
@@ -35,7 +36,7 @@ describe('RunState', () => {
     const agent = new Agent({ name: 'Agent1' });
     const state = new RunState(context, 'input1', agent, 2);
     const json = state.toJSON();
-    expect(json.$schemaVersion).toBe('1.0');
+    expect(json.$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(json.currentTurn).toBe(0);
     expect(json.currentAgent).toEqual({ name: 'Agent1' });
     expect(json.originalInput).toEqual('input1');
@@ -65,7 +66,7 @@ describe('RunState', () => {
     expect(
       async () => await RunState.fromString(agent, JSON.stringify(jsonVersion)),
     ).rejects.toThrow(
-      'Run state schema version 0.1 is not supported. Please use version 1.0',
+      `Run state schema version 0.1 is not supported. Please use version ${CURRENT_SCHEMA_VERSION}`,
     );
   });
 


### PR DESCRIPTION
## Summary
- export CURRENT_SCHEMA_VERSION
- use the constant when serializing a RunState
- update tests to reference the constant

## Testing
- `pnpm -r build-check`
- `CI=1 pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684165b7ee0483299a856a721927ba02