### PR TITLE
Add patch changeset for schema version fix

### DIFF
--- a/.changeset/fix-schema-version-serialization.md
+++ b/.changeset/fix-schema-version-serialization.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+Export CURRENT_SCHEMA_VERSION constant and use it when serializing run state.


### PR DESCRIPTION
## Summary
- revert accidental version bumps
- add patch changeset for `@openai/agents-core`

## Testing
- `pnpm -r build-check`
- `CI=1 pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6841c749e92083298ae4260d2965f98d